### PR TITLE
feat: define CargoDbContext with entity sets and configurations

### DIFF
--- a/src/Cargo.Infrastructure/Data/CargoDbContext.cs
+++ b/src/Cargo.Infrastructure/Data/CargoDbContext.cs
@@ -1,0 +1,34 @@
+using Cargo.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Cargo.Infrastructure.Data;
+
+public class CargoDbContext : DbContext
+{
+    public CargoDbContext(DbContextOptions<CargoDbContext> options) : base(options)
+    {
+    }
+
+    // Aggregate Roots
+    public DbSet<Company> Companies { get; set; }
+    public DbSet<Driver> Drivers { get; set; }
+    public DbSet<Vehicle> Vehicles { get; set; }
+    public DbSet<Route> Routes { get; set; }
+    
+    // Related entities
+    public DbSet<DriverBatch> DriverBatches { get; set; }
+    public DbSet<DriverBatchHourly> DriverBatchHourlies { get; set; }
+    public DbSet<DriverBatchLoad> DriverBatchLoads { get; set; }
+    public DbSet<DriverBatchWait> DriverBatchWaits { get; set; }
+    public DbSet<DriverContract> DriverContracts { get; set; }
+    public DbSet<DriverVehicleAssignment> DriverVehicleAssignments { get; set; }
+    public DbSet<VehicleOwnership> VehicleOwnerships { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        
+        // Apply all configurations from this assembly
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(CargoDbContext).Assembly);
+    }
+}

--- a/src/Cargo.Infrastructure/Data/Configurations/CompanyConfiguration.cs
+++ b/src/Cargo.Infrastructure/Data/Configurations/CompanyConfiguration.cs
@@ -1,0 +1,53 @@
+using Cargo.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Cargo.Infrastructure.Data.Configurations;
+
+public class CompanyConfiguration : IEntityTypeConfiguration<Company>
+{
+    public void Configure(EntityTypeBuilder<Company> builder)
+    {
+        builder.ToTable("Companies");
+        
+        builder.HasKey(c => c.Id);
+        
+        builder.Property(c => c.Name)
+            .IsRequired()
+            .HasMaxLength(200);
+            
+        builder.Property(c => c.RegistrationNumber)
+            .IsRequired()
+            .HasMaxLength(50);
+            
+        // Configure owned types
+        builder.OwnsOne(c => c.Address, address =>
+        {
+            address.Property(a => a.Street).HasColumnName("Address_Street").HasMaxLength(200);
+            address.Property(a => a.City).HasColumnName("Address_City").HasMaxLength(100);
+            address.Property(a => a.State).HasColumnName("Address_State").HasMaxLength(50);
+            address.Property(a => a.ZipCode).HasColumnName("Address_ZipCode").HasMaxLength(20);
+            address.Property(a => a.Country).HasColumnName("Address_Country").HasMaxLength(50);
+        });
+        
+        builder.OwnsOne(c => c.TaxProfile, taxProfile =>
+        {
+            taxProfile.Property(t => t.GstRate).HasColumnName("TaxProfile_GstRate").HasPrecision(5, 4);
+            taxProfile.Property(t => t.QstRate).HasColumnName("TaxProfile_QstRate").HasPrecision(5, 4);
+            taxProfile.Property(t => t.PstRate).HasColumnName("TaxProfile_PstRate").HasPrecision(5, 4);
+            taxProfile.Property(t => t.HstRate).HasColumnName("TaxProfile_HstRate").HasPrecision(5, 4);
+            taxProfile.Property(t => t.CompoundQstOverGst).HasColumnName("TaxProfile_CompoundQstOverGst");
+        });
+        
+        // Configure relationships
+        builder.HasMany(c => c.Drivers)
+            .WithOne(d => d.Company)
+            .HasForeignKey(d => d.CompanyId)
+            .OnDelete(DeleteBehavior.Restrict);
+            
+        builder.HasMany(c => c.Vehicles)
+            .WithOne(v => v.OwnerCompany)
+            .HasForeignKey(v => v.OwnerCompanyId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Cargo.Infrastructure/Data/Configurations/DriverConfiguration.cs
+++ b/src/Cargo.Infrastructure/Data/Configurations/DriverConfiguration.cs
@@ -1,0 +1,57 @@
+using Cargo.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Cargo.Infrastructure.Data.Configurations;
+
+public class DriverConfiguration : IEntityTypeConfiguration<Driver>
+{
+    public void Configure(EntityTypeBuilder<Driver> builder)
+    {
+        builder.ToTable("Drivers");
+        
+        builder.HasKey(d => d.Id);
+        
+        builder.Property(d => d.FirstName)
+            .IsRequired()
+            .HasMaxLength(100);
+            
+        builder.Property(d => d.LastName)
+            .IsRequired()
+            .HasMaxLength(100);
+            
+        builder.Property(d => d.Email)
+            .IsRequired()
+            .HasMaxLength(256);
+            
+        builder.Property(d => d.PhoneNumber)
+            .HasMaxLength(20);
+            
+        builder.Property(d => d.LicenseNumber)
+            .IsRequired()
+            .HasMaxLength(50);
+            
+        builder.Property(d => d.LicenseType)
+            .HasMaxLength(20);
+            
+        // Configure owned types
+        builder.OwnsOne(d => d.Address, address =>
+        {
+            address.Property(a => a.Street).HasColumnName("Address_Street").HasMaxLength(200);
+            address.Property(a => a.City).HasColumnName("Address_City").HasMaxLength(100);
+            address.Property(a => a.State).HasColumnName("Address_State").HasMaxLength(50);
+            address.Property(a => a.ZipCode).HasColumnName("Address_ZipCode").HasMaxLength(20);
+            address.Property(a => a.Country).HasColumnName("Address_Country").HasMaxLength(50);
+        });
+        
+        // Configure relationships
+        builder.HasOne(d => d.Company)
+            .WithMany(c => c.Drivers)
+            .HasForeignKey(d => d.CompanyId)
+            .OnDelete(DeleteBehavior.Restrict);
+            
+        // Indexes
+        builder.HasIndex(d => d.Email).IsUnique();
+        builder.HasIndex(d => d.LicenseNumber).IsUnique();
+    }
+}

--- a/src/Cargo.Infrastructure/Data/Configurations/RouteConfiguration.cs
+++ b/src/Cargo.Infrastructure/Data/Configurations/RouteConfiguration.cs
@@ -1,0 +1,38 @@
+using Cargo.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Cargo.Infrastructure.Data.Configurations;
+
+public class RouteConfiguration : IEntityTypeConfiguration<Route>
+{
+    public void Configure(EntityTypeBuilder<Route> builder)
+    {
+        builder.ToTable("Routes");
+        
+        builder.HasKey(r => r.Id);
+        
+        builder.Property(r => r.Name)
+            .IsRequired()
+            .HasMaxLength(200);
+            
+        builder.Property(r => r.Description)
+            .HasMaxLength(1000);
+            
+        builder.Property(r => r.Origin)
+            .IsRequired()
+            .HasMaxLength(200);
+            
+        builder.Property(r => r.Description)
+            .IsRequired()
+            .HasMaxLength(200);
+            
+        builder.Property(r => r.TotalDistance)
+            .HasPrecision(10, 2);
+            
+        builder.Property(r => r.EstimatedDuration)
+            .HasPrecision(5, 2);
+            
+       
+    }
+}

--- a/src/Cargo.Infrastructure/Data/Configurations/VehicleConfiguration.cs
+++ b/src/Cargo.Infrastructure/Data/Configurations/VehicleConfiguration.cs
@@ -1,0 +1,60 @@
+using Cargo.Domain.Entities;
+using Cargo.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Cargo.Infrastructure.Data.Configurations;
+
+public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
+{
+    public void Configure(EntityTypeBuilder<Vehicle> builder)
+    {
+        builder.ToTable("Vehicles");
+        
+        builder.HasKey(v => v.Id);
+        
+        builder.Property(v => v.Make)
+            .IsRequired()
+            .HasMaxLength(100);
+            
+        builder.Property(v => v.Model)
+            .IsRequired()
+            .HasMaxLength(100);
+            
+        builder.Property(v => v.VIN)
+            .IsRequired()
+            .HasMaxLength(17);
+            
+        builder.Property(v => v.RegistrationNumber)
+            .IsRequired()
+            .HasMaxLength(50);
+            
+        builder.Property(v => v.Color)
+            .HasMaxLength(50);
+            
+        builder.Property(v => v.FuelType)
+            .HasMaxLength(50);
+            
+        builder.Property(v => v.CurrentLocation)
+            .HasMaxLength(200);
+            
+        // Configure owned types
+        builder.OwnsOne(v => v.PlateNumber, plateNumber =>
+        {
+            plateNumber.Property(p => p.Value).HasColumnName("PlateNumber_Value").HasMaxLength(20);
+            plateNumber.Property(p => p.IssuingAuthority).HasColumnName("PlateNumber_IssuingAuthority").HasMaxLength(50);
+        });
+        
+        // Configure relationships
+        builder.HasOne(v => v.OwnerCompany)
+            .WithMany()
+            .HasForeignKey(v => v.OwnerCompanyId)
+            .OnDelete(DeleteBehavior.Restrict);
+            
+        // Indexes
+        builder.HasIndex(v => v.VIN).IsUnique();
+        builder.HasIndex(v => v.RegistrationNumber).IsUnique();
+        builder.HasIndex(v => v.OwnerCompanyId).IsUnique();
+        builder.HasIndex(v => v.DriverId).IsUnique();
+    }
+}


### PR DESCRIPTION
feat: define CargoDbContext with entity sets and configurations

- Declared DbSet properties for core aggregate roots: Company, Driver, Vehicle, Route
- Added related entity sets: DriverBatch, DriverBatchHourly, DriverBatchLoad, DriverBatchWait, DriverContract, DriverVehicleAssignment, VehicleOwnership
- Applied model configurations from assembly in OnModelCreating