### PR TITLE
chore: update appsettings with connection string

### DIFF
--- a/src/Cargo.API/appsettings.json
+++ b/src/Cargo.API/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=CargoDB;Trusted_Connection=True;MultipleActiveResultSets=true"
+  }
 }


### PR DESCRIPTION
chore: update appsettings with connection string

- Added ConnectionStrings section with DefaultConnection to local CargoDB
- Retained AllowedHosts configuration