### PR TITLE
ci: update GitHub Actions workflow for .NET 9 and Cargo.sln

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,28 +1,34 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
-name: .NET
+﻿name: .NET Build & Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      # 1️⃣ Pull the repository code
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2️⃣ Install the specified .NET 9 SDK version
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      # 3️⃣ Restore project dependencies
+      - name: Restore dependencies
+        run: dotnet restore ./Cargo.sln
+
+      # 4️⃣ Build the solution and treat warnings as errors
+      - name: Build
+        run: dotnet build ./Cargo.sln --no-restore --warnaserror
+
+      # 5️⃣ Run all unit tests
+      - name: Test
+        run: dotnet test ./Cargo.sln --no-build --verbosity normal


### PR DESCRIPTION
- Bump .NET SDK to 9.0.x
- Set solution path to Cargo.sln in root
- Enable build warnings as errors
- Allow CI runs on main and dev branches